### PR TITLE
fix(transaction_type): resolves the transaction type

### DIFF
--- a/correpy/parsers/brokerage_notes/b3_parser/b3_parser.py
+++ b/correpy/parsers/brokerage_notes/b3_parser/b3_parser.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date
+from re import sub
 from typing import List
 
 import fitz
@@ -130,6 +131,7 @@ class B3Parser(BaseBrokerageNoteParser):
                     transactions_brokerage_note_section=transactions_brokerage_note_section
                 )
                 for transaction in transactions:
+                    transaction = sub(pattern=r"^N\s", repl="", string=transaction)
                     transaction_item = self._create_transaction(line=transaction)
                     brokerage_note.add_transaction(transaction=transaction_item)
 


### PR DESCRIPTION
Essa pull request resolve o erro na atribuição do tipo de transação.

- Fixes issue #3 

Adicionei uma verificação na string 'transaction' antes da atribuição do 'transaction_item', para remover o 'N' e o espaço caso esteja no início da string. Isto deve resolver a issue.

#### Output:

![image](https://github.com/thiagosalvatore/correpy/assets/38012343/d4d9f569-ae34-459c-b7b4-cf871c0f66d2)

Close #3.

