### PR TITLE
fix(unit_price): Corrects unit price conversion > R$1,000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode/

--- a/correpy/domain/entities/transaction.py
+++ b/correpy/domain/entities/transaction.py
@@ -10,7 +10,7 @@ BRAZIL_SOURCE_WITHHELD_TAX_PERCENTAGE = Decimal(0.005)
 @dataclass
 class Transaction:
     transaction_type: TransactionType
-    amount: int
+    amount: Decimal
     unit_price: Decimal
     security: Security
     source_withheld_taxes: Decimal = field(init=False, default=Decimal(0))

--- a/correpy/parsers/brokerage_notes/base_parser.py
+++ b/correpy/parsers/brokerage_notes/base_parser.py
@@ -14,6 +14,7 @@ from correpy.domain.enums import BrokerageNoteFeeType, TransactionType
 from correpy.parsers.brokerage_notes.brokerage_note_section import BrokerageNoteSection
 from correpy.parsers.brokerage_notes.word_rectangle import WordRectangle
 from correpy.parsers.fitz_parser import FitzParser
+from correpy.utils import extract_value_from_line
 
 
 class BaseBrokerageNoteParser(ABC):
@@ -95,13 +96,11 @@ class BaseBrokerageNoteParser(ABC):
 
     def __parse_transaction_unit_price(self, *, line_array: List[str]) -> Decimal:
         unit_value_string = line_array[self.transaction_columns_index["unit_value"]]
-        unit_value_string = unit_value_string.replace(",", ".")
-        return Decimal(unit_value_string)
+        return extract_value_from_line(line=unit_value_string)
 
-    def __parse_transaction_amount(self, *, line_array: List[str]) -> int:
+    def __parse_transaction_amount(self, *, line_array: List[str]) -> Decimal:
         amount_string = line_array[self.transaction_columns_index["amount"]]
-        amount_string = amount_string.replace(".", "")
-        return int(amount_string)
+        return extract_value_from_line(line=amount_string)
 
     def _create_transaction(self, *, line: str) -> Transaction:
         line_array = line.split(" ")

--- a/correpy/utils.py
+++ b/correpy/utils.py
@@ -2,13 +2,15 @@ import re
 from datetime import date, datetime
 from decimal import Decimal
 
-NUMBER_STRUCTURE_REGEX = r"(?:[1-9]\d{0,2}(?:\.\d{3})*|0)(?:,\d{1,2})"
+NUMBER_STRUCTURE_REGEX = r"(?<![\d(\.|,)])(?:0,\d{2}|[1-9]\d{0,2}(?:\.\d{3})*,\d{2}|[1-9]\d{0,2})(?![\d(\.|,)])"
 DATE_STRUCTURE_REGEX = r"[\d]{1,2}/[\d]{1,2}/[\d]{4}"
 
 
 def extract_value_from_line(*, line: str) -> Decimal:
-    total_value = re.findall(NUMBER_STRUCTURE_REGEX, line)
-    return Decimal(total_value[0].replace(",", ".")) if total_value else Decimal(0)
+    if total_value := re.findall(NUMBER_STRUCTURE_REGEX, line):
+        return Decimal(total_value[0].replace(".", "").replace(",", "."))
+
+    return Decimal(0)
 
 
 def extract_date_from_line(*, line: str) -> date:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,8 +16,8 @@ class SecurityFactory(factory.Factory):
 
 class TransactionFactory(factory.Factory):
     transaction_type = FuzzyChoice(TransactionType)
-    amount = factory.Faker("pyint")
-    unit_price = factory.Faker("pydecimal", right_digits=2, max_value=1000, min_value=1, positive=True)
+    amount = factory.Faker("pydecimal", max_value=100000, min_value=1, positive=True)
+    unit_price = factory.Faker("pydecimal", right_digits=2, max_value=10000, min_value=1, positive=True)
     security = factory.SubFactory(SecurityFactory)
 
     class Meta:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pytest import mark
+
+from correpy.utils import extract_date_from_line, extract_value_from_line
+
+
+@mark.parametrize(
+    "input_string, expected_result",
+    [
+        ("MINERVA ON NM 2,50", Decimal("2.50")),
+        ("Faria 1.200,50", Decimal("1200.50")),
+        ("   1.962,90   ", Decimal("1962.90")),
+        ("Idade 200  123", Decimal("200")),
+        ("PETZ qtd 10", Decimal("10")),
+        ("C VISTA 10,99", Decimal("10.99")),
+        ("Saida 123 VISTA", Decimal("123")),
+        ("Erro 13.33", Decimal("0")),
+        ("Senha 1000", Decimal("0")),
+        ("Zero 000###", Decimal("0")),
+        ("    0.00 ", Decimal("0")),
+        ("CI ER 091", Decimal("0")),
+        ("Valor 0021,00", Decimal("0")),
+        ("02.0", Decimal("0")),
+    ],
+)
+
+def test_extract_value_from_line_when_called_then_returns_value_correctly(input_string, expected_result):
+    assert extract_value_from_line(line=input_string) == expected_result
+
+
+def test_extract_value_from_line_when_called_within_value_then_return_zero_value():
+    assert extract_value_from_line(line="... ") == Decimal("0")
+
+
+def test_extract_date_from_line_when_called_then_returns_date_correctly():
+    date_string = " 03/02/2024 "
+    expected_result = datetime.strptime("03/02/2024", "%d/%m/%Y").date()
+    assert extract_date_from_line(line=date_string) == expected_result


### PR DESCRIPTION
### Context
When transactions have unit prices greater than R$ 1.000,00 the code crashes, because it is unable to convert unit prices with "." into a decimal.

- Fixes issue #5 [ #8  ]

Both `unit_price` and `amount` are parsed by the `extract_value_from_line` method and return the correct values.

The change ensures that no error occurs when converting the unit price and changes amount parse to Decimal now.

I added test_utils to make sure the Regex is ok.

Close #5