### PR TITLE
Extração do número da nota (ID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,21 +80,22 @@ Abaixo você pode encontrar a descrição de cada um dos campos retornados.
 
 #### Brokerage Note
 
-| BrokerageNote    |                                     |
-|------------------|-------------------------------------|
-| reference_date   | Data do pregão                      |
-| settlement_fee   | Taxa de liquidação                  |
-| registration_fee | Taxa de registro                    |
-| term_fee         | Taxa de termo/opções                |
-| ana_fee          | Taxa A.N.A                          |
-| emoluments       | Emolumentos                         |
-| operational_fee  | Taxa Operacional                    |
-| execution        | Execução                            |
-| custody_fee      | Taxa de custódia                    |
-| source_withheld_taxes  | IRRF                    |
-| taxes            | Impostos                            |
-| others           | Outros                              |
-| transactions     | Lista de [transações](#transaction) |
+| BrokerageNote         |                                     |
+|-----------------------|-------------------------------------|
+| reference_id          | Número da nota                      |
+| reference_date        | Data do pregão                      |
+| settlement_fee        | Taxa de liquidação                  |
+| registration_fee      | Taxa de registro                    |
+| term_fee              | Taxa de termo/opções                |
+| ana_fee               | Taxa A.N.A                          |
+| emoluments            | Emolumentos                         |
+| operational_fee       | Taxa Operacional                    |
+| execution             | Execução                            |
+| custody_fee           | Taxa de custódia                    |
+| source_withheld_taxes | IRRF                    |
+| taxes                 | Impostos                            |
+| others                | Outros                              |
+| transactions          | Lista de [transações](#transaction) |
 
 #### Transaction
 

--- a/correpy/domain/entities/brokerage_note.py
+++ b/correpy/domain/entities/brokerage_note.py
@@ -10,8 +10,8 @@ from correpy.domain.exceptions import InvalidBrokerageNoteFeeTypeException
 
 @dataclass
 class BrokerageNote:  # pylint:disable=too-many-instance-attributes
-    reference_date: date
     reference_id: int
+    reference_date: date
     settlement_fee: Decimal = Decimal(0)
     registration_fee: Decimal = Decimal(0)
     term_fee: Decimal = Decimal(0)

--- a/correpy/domain/entities/brokerage_note.py
+++ b/correpy/domain/entities/brokerage_note.py
@@ -11,6 +11,7 @@ from correpy.domain.exceptions import InvalidBrokerageNoteFeeTypeException
 @dataclass
 class BrokerageNote:  # pylint:disable=too-many-instance-attributes
     reference_date: date
+    reference_id: int
     settlement_fee: Decimal = Decimal(0)
     registration_fee: Decimal = Decimal(0)
     term_fee: Decimal = Decimal(0)

--- a/correpy/domain/entities/security.py
+++ b/correpy/domain/entities/security.py
@@ -8,8 +8,11 @@ from typing import Optional
 # 6	Preferenciais Classe B / ELET6
 # 11 BDRs, ETs e Units / BOVA11
 
-BASIC_TICKER_PATTERN = "([A-Z-0-9]{4})(2|3|4|5|6|11|12)(F|B)?"  # Format XXXXY or XXXXYF or XXXXYB where Y can be 3, 4, 11
-BDR_TICKER_PATTERN = "([A-Z-0-9]{4})(31|32|33|34|35|36|39)"  # Format XXXXYY where YY can be 31, 32, 33, 34, 35, 36, 39
+# Format XXXXY or XXXXYF or XXXXYB where Y can be 3, 4, 11
+BASIC_TICKER_PATTERN = "([A-Z-0-9]{4})(2|3|4|5|6|11|12)(F|B)?"
+
+# Format XXXXYY where YY can be 31, 32, 33, 34, 35, 36, 39
+BDR_TICKER_PATTERN = "([A-Z-0-9]{4})(31|32|33|34|35|36|39)"
 
 
 @dataclass

--- a/correpy/parsers/brokerage_notes/b3_parser/nuinvest.py
+++ b/correpy/parsers/brokerage_notes/b3_parser/nuinvest.py
@@ -7,7 +7,8 @@ from correpy.parsers.brokerage_notes.brokerage_note_section import BrokerageNote
 
 
 class NunInvestParser(B3Parser):
-	CI_TITLE = "Pav. 14, 15 - Torre A2 Jequitibá - Condomínio Parque da Cidade"
+	REFERENCE_NOTE_ID = "Número da nota"
+	CI_TITLE = "Valor/Ajuste D/C"
 	TRANSACTIONS_SECTION_TITLE = 'Nome do Cliente'
 	TRANSACTIONS_SUMMARY_TITLE = (
 		# sigle page

--- a/correpy/parsers/brokerage_notes/base_parser.py
+++ b/correpy/parsers/brokerage_notes/base_parser.py
@@ -16,11 +16,13 @@ from correpy.parsers.brokerage_notes.word_rectangle import WordRectangle
 from correpy.parsers.fitz_parser import FitzParser
 from correpy.utils import extract_value_from_line
 
+NoteKey = tuple[int, date]
+
 
 class BaseBrokerageNoteParser(ABC):
     def __init__(self, brokerage_note: io.BytesIO, password: Optional[str] = None) -> None:
         self.fitz_parser = FitzParser(file=brokerage_note, password=password)
-        self.brokerage_notes: Dict[date, BrokerageNote] = {}
+        self.brokerage_notes: Dict[NoteKey, BrokerageNote] = {}
 
     @property
     @abstractmethod

--- a/correpy/parsers/fitz_parser.py
+++ b/correpy/parsers/fitz_parser.py
@@ -30,9 +30,8 @@ class FitzParser:
     def search_and_extract_rectangle_from_text(cls, *, page: TextPage, text: Union[str, List[str]]) -> fitz.Rect:
         if isinstance(text, str):
             text = [text]
-        for text in text:
-            # multitext search
-            if quadrilateral_position := page.search(text):
+        for value in text:  # multi-text search
+            if quadrilateral_position := page.search(value):
                 break
         else:
             quadrilateral_position = None

--- a/correpy/utils.py
+++ b/correpy/utils.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 NUMBER_STRUCTURE_REGEX = r"(?<![\d(\.|,)])(?:0,\d{2}|[1-9]\d{0,2}(?:\.\d{3})*,\d{2}|[1-9]\d{0,2})(?![\d(\.|,)])"
 DATE_STRUCTURE_REGEX = r"[\d]{1,2}/[\d]{1,2}/[\d]{4}"
+ID_STRUCTURE_REGEX = r'^\D*(\d+)'
 
 
 def extract_value_from_line(*, line: str) -> Decimal:
@@ -16,3 +17,8 @@ def extract_value_from_line(*, line: str) -> Decimal:
 def extract_date_from_line(*, line: str) -> date:
     reference_date_string = re.findall(DATE_STRUCTURE_REGEX, line)[0]
     return datetime.strptime(reference_date_string, "%d/%m/%Y").date()
+
+
+def extract_id_from_line(*, line: str) -> int:
+    """Extraction of the note id (number)"""
+    return int(re.search(ID_STRUCTURE_REGEX, line).group(1))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,3 +1,5 @@
+import sys
+
 import factory
 from factory.fuzzy import FuzzyChoice
 
@@ -25,6 +27,7 @@ class TransactionFactory(factory.Factory):
 
 
 class BrokerageNoteFactory(factory.Factory):
+    reference_id = factory.Faker("random_int", min=1000, max=sys.maxsize)
     reference_date = factory.Faker("date_object")
     settlement_fee = factory.Faker("pydecimal", right_digits=2, max_value=1000, min_value=1, positive=True)
     registration_fee = factory.Faker("pydecimal", right_digits=2, max_value=1000, min_value=1, positive=True)

--- a/tests/integrations/parsers/brokerage_notes/test_b3_parser.py
+++ b/tests/integrations/parsers/brokerage_notes/test_b3_parser.py
@@ -20,6 +20,7 @@ def test_b3_parser_WHEN_called_with_single_page_note_THEN_correctly_parses_broke
         content.seek(0)
         expected_result = [
             BrokerageNote(
+                reference_id=4535159,
                 reference_date=date(2022, 5, 2),
                 settlement_fee=Decimal("7.92"),
                 registration_fee=Decimal("0"),


### PR DESCRIPTION
Tive a necessidade de extrair o número da nota, que em conjunto com a data de pregão, serão usados garantir um registro único de nota no banco de dados. Não sei se essa informação será útil para você mas fiz todos os teste possíveis (inclusive executando os teste unitários) e parece que está tudo executando normalmente.