### PR TITLE
Covers more quantity formats from bokerage notes

### DIFF
--- a/correpy/utils.py
+++ b/correpy/utils.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 from decimal import Decimal
 
-NUMBER_STRUCTURE_REGEX = r"(?<![\d(\.|,)])(?:0,\d{2}|[1-9]\d{0,2}(?:\.\d{3})*,\d{2}|[1-9]\d{0,2})(?![\d(\.|,)])"
+NUMBER_STRUCTURE_REGEX = r"(?<![\d(\.|,)])(?:0,\d{2}|\d+\.?\d{3}(?!,)|[1-9]\d{0,2}(?:\.\d{3})*,\d{2}|[1-9]\d{0,2})(?![\d(\.|,)])"
 DATE_STRUCTURE_REGEX = r"[\d]{1,2}/[\d]{1,2}/[\d]{4}"
 ID_STRUCTURE_REGEX = r'^\D*(\d+)'
 


### PR DESCRIPTION
This change covers quantities expressed without decimal places, like 1000, 1.000, 15.000, etc.

Fixes the issue: #16 