### PR TITLE
Corrigido problema para extrair a quantidade dos ativos

### DIFF
--- a/correpy/parsers/brokerage_notes/b3_parser/b3_parser.py
+++ b/correpy/parsers/brokerage_notes/b3_parser/b3_parser.py
@@ -198,7 +198,6 @@ class B3Parser(BaseBrokerageNoteParser):
                 )
 
             except ProblemParsingBrokerageNoteException as exc:
-                print(exc)
                 continue
 
     def __set_brokerage_note_fees(

--- a/correpy/parsers/brokerage_notes/base_parser.py
+++ b/correpy/parsers/brokerage_notes/base_parser.py
@@ -14,7 +14,7 @@ from correpy.domain.enums import BrokerageNoteFeeType, TransactionType
 from correpy.parsers.brokerage_notes.brokerage_note_section import BrokerageNoteSection
 from correpy.parsers.brokerage_notes.word_rectangle import WordRectangle
 from correpy.parsers.fitz_parser import FitzParser
-from correpy.utils import extract_value_from_line
+from correpy.utils import extract_value_from_line, extract_amount_from_line
 
 NoteKey = tuple[int, date]
 
@@ -102,7 +102,7 @@ class BaseBrokerageNoteParser(ABC):
 
     def __parse_transaction_amount(self, *, line_array: List[str]) -> Decimal:
         amount_string = line_array[self.transaction_columns_index["amount"]]
-        return extract_value_from_line(line=amount_string)
+        return extract_amount_from_line(line=amount_string)
 
     def _create_transaction(self, *, line: str) -> Transaction:
         line_array = line.split(" ")

--- a/correpy/utils.py
+++ b/correpy/utils.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 NUMBER_STRUCTURE_REGEX = r"(?<![\d(\.|,)])(?:0,\d{2}|[1-9]\d{0,2}(?:\.\d{3})*,\d{2}|[1-9]\d{0,2})(?![\d(\.|,)])"
+AMOUNT_STRUCTURE_REGEX = r"(?<![\d.,])(?:0|[1-9]\d{0,2}(?:\.\d{3})*)(?![\d.,])"
 DATE_STRUCTURE_REGEX = r"[\d]{1,2}/[\d]{1,2}/[\d]{4}"
 ID_STRUCTURE_REGEX = r'^\D*(\d+)'
 
@@ -10,6 +11,13 @@ ID_STRUCTURE_REGEX = r'^\D*(\d+)'
 def extract_value_from_line(*, line: str) -> Decimal:
     if total_value := re.findall(NUMBER_STRUCTURE_REGEX, line):
         return Decimal(total_value[-1].replace(".", "").replace(",", "."))
+
+    return Decimal(0)
+
+
+def extract_amount_from_line(*, line: str) -> Decimal:
+    if total_value := re.findall(AMOUNT_STRUCTURE_REGEX, line):
+        return Decimal(total_value[-1].replace(".", ""))
 
     return Decimal(0)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from pytest import mark
 
-from correpy.utils import extract_date_from_line, extract_value_from_line
+from correpy.utils import extract_date_from_line, extract_value_from_line, extract_amount_from_line
 
 
 @mark.parametrize(
@@ -25,13 +25,28 @@ from correpy.utils import extract_date_from_line, extract_value_from_line
         ("02.0", Decimal("0")),
     ],
 )
-
 def test_extract_value_from_line_when_called_then_returns_value_correctly(input_string, expected_result):
     assert extract_value_from_line(line=input_string) == expected_result
 
 
 def test_extract_value_from_line_when_called_within_value_then_return_zero_value():
     assert extract_value_from_line(line="... ") == Decimal("0")
+
+@mark.parametrize(
+    "input_string, expected_result",
+    [
+        ("1", Decimal("1")),
+        ("100", Decimal("100")),
+        ("999", Decimal("999")),
+        ("2.000", Decimal("2000")),
+        ("3.000", Decimal("3000")),
+        ("1.000.000", Decimal("1000000")),
+        ("1.000.000,00", Decimal("0")),
+    ],
+)
+def test_extract_amount_value_from_line_when_called_then_returns_value_correctly(input_string, expected_result):
+    """Test quantities with digit class separator"""
+    assert extract_amount_from_line(line=input_string) == expected_result
 
 
 def test_extract_date_from_line_when_called_then_returns_date_correctly():


### PR DESCRIPTION
Pelo menos na nota nuninvest, tive uma quantidade `3.000`  e código de extração de valores não conseguiu extrair esse número, resultando em 0.
Embora a quantidade seja um  `Decimal`, ela não tem a parte fracionária e isso entra em conflito com valores monetários.
Eu separei o código para evitar maiores problemas e fiz teste para extração desse formato número.