### PR TITLE
README.md atualizado de 'parse_brokerage_note' para 'parse'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ with open('path to your pdf file', 'rb') as f:
     content = io.BytesIO(f.read())
     content.seek(0)
     
-    brokerage_notes = ParserFactory(brokerage_note=content, password="password").parse_brokerage_note()
+    brokerage_notes = ParserFactory(brokerage_note=content, password="password").parse()
 ```
 
 ### Resultado


### PR DESCRIPTION
O README está desatualizado no exemplo do `ParserFactory`. O método `parse_brokerage_note()` não é definido na classe `ParserFactory`, mas sim o `parse()`.